### PR TITLE
Move to Embedded Hal 1.0.0, and operate on non-floating-point processors

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,0 @@
-[target.thumbv7em-none-eabihf]
-rustflags = [
-  "-C", "link-arg=-Tlink.x",
-]
-
-[build]
-target = "thumbv7em-none-eabihf"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,8 +4,4 @@ rustflags = ["-C", "link-arg=-Tlink.x"]
 [target.thumbv7em-none-eabihf]
 rustflags = ["-C", "link-arg=-Tlink.x"]
 
-[build.'cfg(not(feature = "lux_as_f32"))']
-target = "thumbv7em-none-eabi"
-
-[build.'cfg(feature = "lux_as_f32")']
 target = "thumbv7em-none-eabihf"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,5 @@ rustflags = ["-C", "link-arg=-Tlink.x"]
 [target.thumbv7em-none-eabihf]
 rustflags = ["-C", "link-arg=-Tlink.x"]
 
+[build]
 target = "thumbv7em-none-eabihf"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.thumbv7em-none-eabi]
+rustflags = ["-C", "link-arg=-Tlink.x"]
+
+[target.thumbv7em-none-eabihf]
+rustflags = ["-C", "link-arg=-Tlink.x"]
+
+[build.'cfg(not(feature = "lux_as_f32"))']
+target = "thumbv7em-none-eabi"
+
+[build.'cfg(feature = "lux_as_f32")']
+target = "thumbv7em-none-eabihf"

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,33 @@
+// cSpell Settings
+{
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
+    // language - current active spelling language
+    "language": "en",
+    // words - list of words to be always considered correct
+    "words": [
+        "baudrate",
+        "cfgr",
+        "datasheet",
+        "eabihf",
+        "GPIOA",
+        "GPIOB",
+        "MicroMath",
+        "Nucleo",
+        "photodiode",
+        "rustflags",
+        "thumbv",
+        "Tlink",
+        "USART",
+        "VEML6030",
+        "VEML6040",
+        "VEML7700",
+        "Vishay"
+    ],
+    // flagWords - list of words to be always considered incorrect
+    // This is useful for offensive words and common spelling errors.
+    "flagWords": [
+        "hte",
+        "teh"
+    ]
+}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -15,6 +15,7 @@
         "MicroMath",
         "Nucleo",
         "photodiode",
+        "powf",
         "rustflags",
         "thumbv",
         "Tlink",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.check.extraArgs": [
+        "--target",
+        "thumbv7em-none-eabi"
+    ],
+    "rust-analyzer.imports.prefer.no.std": true,
+    "rust-analyzer.showUnlinkedFileNotification": false,
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lux_as_f32 = ["micromath"]
 lux_as_u32 = []
 
 [dependencies]
-embedded-hal = "1.0.0-rc.1"
+embedded-hal = "1.0.0"
 micromath = { version = "2.0", optional = true }
 
 [dev-dependencies]
@@ -31,9 +31,7 @@ panic-halt = "0.2.0"
 # stm32f4xx-hal = { version = "0.17.1", features = ["rt", "stm32f401"] }
 # see https://github.com/stm32-rs/stm32f4xx-hal/issues/686
 # Examples on hold until this works
-rtt-target = { version = "0.3.1", features = [
-    "cortex-m",
-] } # back-version due to https://github.com/probe-rs/rtt-target/issues/33
+rtt-target = "0.5.0"
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,25 +3,32 @@ name = "veml7700"
 version = "0.1.7"
 edition = "2018"
 categories = ["embedded", "hardware-support", "no-std"]
-authors = ["Diego Barrios Romero <eldruin@gmail.com>", "Boris Vinogradov <no111u3@gmail.com>"]
+authors = [
+    "Diego Barrios Romero <eldruin@gmail.com>",
+    "Boris Vinogradov <no111u3@gmail.com>",
+]
 description = "Platform-agnostic Rust driver for the VEML7700 High Accuracy Ambient Light Sensor"
 documentation = "https://docs.rs/veml7700"
 keywords = ["als", "ambient", "light", "sensor", "embedded-hal-driver"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/no111u3/veml7700"
-exclude = [ "memory.x", ".cargo", "Embed.toml" ]
+exclude = ["memory.x", ".cargo", "Embed.toml"]
+
+[features]
+default = ["lux_as_f32"]
+lux_as_f32 = ["micromath"]
+lux_as_u32 = []
 
 [dependencies]
 embedded-hal = "0.2"
-micromath = "2.0"
-
+micromath = { version = "2.0", optional = true }
 
 [dev-dependencies]
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
-stm32f4xx-hal = { version = "0.8", features = ["rt", "stm32f401"]}
+stm32f4xx-hal = { version = "0.8", features = ["rt", "stm32f401"] }
 rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,7 @@ micromath = { version = "2.0", optional = true }
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.3"
 panic-halt = "0.2.0"
-# stm32f4xx-hal = { version = "0.17.1", features = ["rt", "stm32f401"] }
-# see https://github.com/stm32-rs/stm32f4xx-hal/issues/686
-# Examples on hold until this works
+stm32f4xx-hal = { version = "0.20.0", features = ["stm32f401"] }
 rtt-target = "0.5.0"
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,13 @@ embedded-hal = "0.2"
 micromath = { version = "2.0", optional = true }
 
 [dev-dependencies]
-cortex-m = "0.6.2"
-cortex-m-rt = "0.6.12"
+cortex-m = "0.7.7"
+cortex-m-rt = "0.7.3"
 panic-halt = "0.2.0"
-stm32f4xx-hal = { version = "0.8", features = ["rt", "stm32f401"] }
-rtt-target = { version = "0.2.0", features = ["cortex-m"] }
+stm32f4xx-hal = { version = "0.17.1", features = ["rt", "stm32f401"] }
+rtt-target = { version = "0.3.1", features = [
+    "cortex-m",
+] } # back-version due to https://github.com/probe-rs/rtt-target/issues/33
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cortex-m-rt = "0.7.3"
 panic-halt = "0.2.0"
 stm32f4xx-hal = { version = "0.20.0", features = ["stm32f401"] }
 rtt-target = "0.5.0"
-panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
+# panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
 
 [profile.release]
 # Many of these settings are highly recommended or required for embedded work

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veml7700"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 categories = ["embedded", "hardware-support", "no-std"]
 authors = [
@@ -21,14 +21,16 @@ lux_as_f32 = ["micromath"]
 lux_as_u32 = []
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = "1.0.0-rc.1"
 micromath = { version = "2.0", optional = true }
 
 [dev-dependencies]
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.3"
 panic-halt = "0.2.0"
-stm32f4xx-hal = { version = "0.17.1", features = ["rt", "stm32f401"] }
+# stm32f4xx-hal = { version = "0.17.1", features = ["rt", "stm32f401"] }
+# see https://github.com/stm32-rs/stm32f4xx-hal/issues/686
+# Examples on hold until this works
 rtt-target = { version = "0.3.1", features = [
     "cortex-m",
 ] } # back-version due to https://github.com/probe-rs/rtt-target/issues/33

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "veml7700"
 version = "0.1.7"
-edition = "2018"
+edition = "2021"
 categories = ["embedded", "hardware-support", "no-std"]
 authors = [
     "Diego Barrios Romero <eldruin@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Rust VEML7700 High Accuracy Ambient Light Sensor Driver
+
 [![crates.io](https://img.shields.io/crates/v/veml7700.svg)](https://crates.io/crates/veml7700)
 [![Docs](https://docs.rs/veml7700/badge.svg)](https://docs.rs/veml7700)
 
@@ -7,6 +8,7 @@ light sensors using the [`embedded-hal`] traits. It's alternative version of
 [`veml6030`] crate that uses the [`micromath`] library and 32 bit precision for sensor correction.
 
 This driver allows you to:
+
 - Enable/disable the device. See: `enable()`.
 - Read the measured lux value. See: `read_lux()`.
 - Read the white channel measurement. See: `read_white()`.
@@ -23,7 +25,7 @@ This driver allows you to:
 
 ## The device
 
-Vishay's VEML7700 are high accuracy ambient light digital 16-bit
+The Vishay VEML7700 is a high accuracy ambient light digital 16-bit
 resolution sensor in a miniature transparent package. It includes
 a high sensitive photodiode, a low noise amplifier, a 16-bit A/D converter
 and support an easy to use I2C bus communication interface and additional
@@ -33,6 +35,7 @@ The ambient light result is as digital value available.
 Datasheet:[VEML7700](https://www.vishay.com/docs/84286/veml7700.pdf)
 
 Application Note:
+
 - [Designing the VEML7700 into an application](https://www.vishay.com/docs/84323/designingveml7700.pdf)
 
 ## Usage
@@ -51,10 +54,10 @@ For questions, issues, feature requests, and other changes, please file an
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-   http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+   <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   <http://opensource.org/licenses/MIT>)
 
 at your option.
 
@@ -67,4 +70,3 @@ be dual licensed as above, without any additional terms or conditions.
 [`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
 [`micromath`]: https://github.com/tarcieri/micromath
 [`veml6030`]: https://github.com/eldruin/veml6030-rs
-

--- a/examples/ambient_light.rs
+++ b/examples/ambient_light.rs
@@ -70,8 +70,18 @@ fn main() -> ! {
         led.set_high().ok();
         // current light state in lux and white light state
         let white = veml7700_device.read_white().unwrap();
-        let lux = veml7700_device.read_lux().unwrap();
-        writeln!(tx, "White: {}, Lux: {:2}\r", white, lux).ok();
+
+        #[cfg(feature = "lux_as_f32")]
+        {
+            let lux = veml7700_device.read_lux().unwrap();
+            writeln!(tx, "White: {}, Lux: {:2}\r", white, lux).ok();
+        }
+        #[cfg(not(feature = "lux_as_f32"))]
+        {
+            let raw = veml7700_device.read_raw().unwrap();
+            writeln!(tx, "White: {}, Raw: {:#06x}", white, raw).ok();
+        }
+
         led.set_low().ok();
         delay.delay_ms(100u16);
     }

--- a/examples/ambient_light.rs
+++ b/examples/ambient_light.rs
@@ -8,11 +8,10 @@ use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use stm32f4xx_hal::{
-    delay::Delay,
-    i2c::I2c,
+    i2c::{I2c, Mode},
     prelude::*,
     serial::{config::Config, Serial},
-    stm32,
+    pac as stm32,
 };
 
 use core::fmt::Write;
@@ -31,43 +30,43 @@ fn main() -> ! {
     let clocks = rcc.cfgr.freeze();
 
     let mut led = gpioa.pa5.into_push_pull_output();
-    led.set_low().ok();
+    led.set_low();
 
-    let tx = gpioa.pa2.into_alternate_af7();
-    let rx = gpioa.pa3.into_alternate_af7();
+    let tx = gpioa.pa2.into_alternate();
+    let rx = gpioa.pa3.into_alternate();
 
     let config = Config::default().baudrate(4_800.bps());
 
-    let serial = Serial::usart2(p.USART2, (tx, rx), config, clocks).unwrap();
+    let serial = Serial::new(p.USART2, (tx, rx), config, &clocks).unwrap();
 
     let (mut tx, _rx) = serial.split();
 
     let gpiob = p.GPIOB.split();
     let scl = gpiob
         .pb8
-        .into_alternate_af4()
+        .into_alternate()
         .internal_pull_up(true)
         .set_open_drain();
 
     let sda = gpiob
         .pb9
-        .into_alternate_af4()
+        .into_alternate()
         .internal_pull_up(true)
         .set_open_drain();
 
-    let i2c = I2c::i2c1(p.I2C1, (scl, sda), 200.khz(), clocks);
+    let i2c = I2c::new(p.I2C1, (scl, sda), Mode::Standard { frequency: _fugit_RateExtU32::kHz(200) }, &clocks);
 
     writeln!(tx, "Ambient light sensor from Nucleo F401RE\r").ok();
 
     // Initialize the VEML7700 with the I2C
     let mut veml7700_device = Veml7700::new(i2c);
 
-    let mut delay = Delay::new(cp.SYST, clocks);
+    let mut delay = cp.SYST.delay(&clocks);
 
     veml7700_device.enable().unwrap();
 
     loop {
-        led.set_high().ok();
+        led.set_high();
         // current light state in lux and white light state
         let white = veml7700_device.read_white().unwrap();
 
@@ -82,7 +81,7 @@ fn main() -> ! {
             writeln!(tx, "White: {}, Raw: {:#06x}", white, raw).ok();
         }
 
-        led.set_low().ok();
-        delay.delay_ms(100u16);
+        led.set_low();
+        delay.delay_ms(100);
     }
 }

--- a/examples/enable_power_saving_mode.rs
+++ b/examples/enable_power_saving_mode.rs
@@ -8,11 +8,10 @@ use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use stm32f4xx_hal::{
-    delay::Delay,
-    i2c::I2c,
+    i2c::{I2c, Mode},
     prelude::*,
     serial::{config::Config, Serial},
-    stm32,
+    pac as stm32,
 };
 
 use core::fmt::Write;
@@ -31,38 +30,38 @@ fn main() -> ! {
     let clocks = rcc.cfgr.freeze();
 
     let mut led = gpioa.pa5.into_push_pull_output();
-    led.set_low().ok();
+    led.set_low();
 
-    let tx = gpioa.pa2.into_alternate_af7();
-    let rx = gpioa.pa3.into_alternate_af7();
+    let tx = gpioa.pa2.into_alternate();
+    let rx = gpioa.pa3.into_alternate();
 
     let config = Config::default().baudrate(4_800.bps());
 
-    let serial = Serial::usart2(p.USART2, (tx, rx), config, clocks).unwrap();
+    let serial = Serial::new(p.USART2, (tx, rx), config, &clocks).unwrap();
 
     let (mut tx, _rx) = serial.split();
 
     let gpiob = p.GPIOB.split();
     let scl = gpiob
         .pb8
-        .into_alternate_af4()
+        .into_alternate()
         .internal_pull_up(true)
         .set_open_drain();
 
     let sda = gpiob
         .pb9
-        .into_alternate_af4()
+        .into_alternate()
         .internal_pull_up(true)
         .set_open_drain();
 
-    let i2c = I2c::i2c1(p.I2C1, (scl, sda), 200.khz(), clocks);
+    let i2c = I2c::new(p.I2C1, (scl, sda), Mode::Standard { frequency: _fugit_RateExtU32::kHz(200) }, &clocks);
 
     writeln!(tx, "Ambient light sensor from Nucleo F401RE\r").ok();
 
     // Initialize the VEML7700 with the I2C
     let mut veml7700_device = Veml7700::new(i2c);
 
-    let mut delay = Delay::new(cp.SYST, clocks);
+    let mut delay = cp.SYST.delay(&clocks);
 
     veml7700_device
         .enable_power_saving(PowerSavingMode::One)
@@ -70,7 +69,7 @@ fn main() -> ! {
     veml7700_device.enable().unwrap();
 
     loop {
-        led.set_high().ok();
+        led.set_high();
         // current light state in lux and white light state
         let white = veml7700_device.read_white().unwrap();
         #[cfg(feature = "lux_as_f32")]
@@ -83,7 +82,8 @@ fn main() -> ! {
             let raw = veml7700_device.read_raw().unwrap();
             writeln!(tx, "White: {}, Raw: {:#06x}", white, raw).ok();
         }
-        led.set_low().ok();
-        delay.delay_ms(100u16);
+
+        led.set_low();
+        delay.delay_ms(100);
     }
 }

--- a/examples/enable_power_saving_mode.rs
+++ b/examples/enable_power_saving_mode.rs
@@ -73,8 +73,16 @@ fn main() -> ! {
         led.set_high().ok();
         // current light state in lux and white light state
         let white = veml7700_device.read_white().unwrap();
-        let lux = veml7700_device.read_lux().unwrap();
-        writeln!(tx, "White: {}, Lux: {:2}\r", white, lux).ok();
+        #[cfg(feature = "lux_as_f32")]
+        {
+            let lux = veml7700_device.read_lux().unwrap();
+            writeln!(tx, "White: {}, Lux: {:2}\r", white, lux).ok();
+        }
+        #[cfg(not(feature = "lux_as_f32"))]
+        {
+            let raw = veml7700_device.read_raw().unwrap();
+            writeln!(tx, "White: {}, Raw: {:#06x}", white, raw).ok();
+        }
         led.set_low().ok();
         delay.delay_ms(100u16);
     }

--- a/examples/gain_integration_time.rs
+++ b/examples/gain_integration_time.rs
@@ -74,8 +74,16 @@ fn main() -> ! {
         led.set_high().ok();
         // current light state in lux and white light state
         let white = veml7700_device.read_white().unwrap();
-        let lux = veml7700_device.read_lux().unwrap();
-        writeln!(tx, "White: {}, Lux: {:2}\r", white, lux).ok();
+        #[cfg(feature = "lux_as_f32")]
+        {
+            let lux = veml7700_device.read_lux().unwrap();
+            writeln!(tx, "White: {}, Lux: {:2}\r", white, lux).ok();
+        }
+        #[cfg(not(feature = "lux_as_f32"))]
+        {
+            let raw = veml7700_device.read_raw().unwrap();
+            writeln!(tx, "White: {}, Raw: {:#06x}", white, raw).ok();
+        }
         led.set_low().ok();
         delay.delay_ms(100u16);
     }

--- a/examples/thresholds_faults_interrupts.rs
+++ b/examples/thresholds_faults_interrupts.rs
@@ -8,11 +8,10 @@ use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use stm32f4xx_hal::{
-    delay::Delay,
-    i2c::I2c,
+    i2c::{I2c, Mode},
     prelude::*,
     serial::{config::Config, Serial},
-    stm32,
+    pac as stm32,
 };
 
 use core::fmt::Write;
@@ -31,38 +30,38 @@ fn main() -> ! {
     let clocks = rcc.cfgr.freeze();
 
     let mut led = gpioa.pa5.into_push_pull_output();
-    led.set_low().ok();
+    led.set_low();
 
-    let tx = gpioa.pa2.into_alternate_af7();
-    let rx = gpioa.pa3.into_alternate_af7();
+    let tx = gpioa.pa2.into_alternate();
+    let rx = gpioa.pa3.into_alternate();
 
     let config = Config::default().baudrate(4_800.bps());
 
-    let serial = Serial::usart2(p.USART2, (tx, rx), config, clocks).unwrap();
+    let serial = Serial::new(p.USART2, (tx, rx), config, &clocks).unwrap();
 
     let (mut tx, _rx) = serial.split();
 
     let gpiob = p.GPIOB.split();
     let scl = gpiob
         .pb8
-        .into_alternate_af4()
+        .into_alternate()
         .internal_pull_up(true)
         .set_open_drain();
 
     let sda = gpiob
         .pb9
-        .into_alternate_af4()
+        .into_alternate()
         .internal_pull_up(true)
         .set_open_drain();
 
-    let i2c = I2c::i2c1(p.I2C1, (scl, sda), 200.khz(), clocks);
+    let i2c = I2c::new(p.I2C1, (scl, sda), Mode::Standard { frequency: _fugit_RateExtU32::kHz(200) }, &clocks);
 
     writeln!(tx, "Ambient light sensor from Nucleo F401RE\r").ok();
 
     // Initialize the VEML7700 with the I2C
     let mut veml7700_device = Veml7700::new(i2c);
 
-    let mut delay = Delay::new(cp.SYST, clocks);
+    let mut delay = cp.SYST.delay(&clocks);
 
     veml7700_device.set_gain(Gain::OneQuarter).unwrap();
     veml7700_device
@@ -84,7 +83,7 @@ fn main() -> ! {
     veml7700_device.enable().unwrap();
 
     loop {
-        led.set_high().ok();
+        led.set_high();
         // current light state in lux and white light state
         let white = veml7700_device.read_white().unwrap();
 
@@ -105,7 +104,7 @@ fn main() -> ! {
         if status.was_too_low {
             writeln!(tx, "To low ambient\r").ok();
         }
-        led.set_low().ok();
-        delay.delay_ms(100u16);
+        led.set_low();
+        delay.delay_ms(100);
     }
 }

--- a/src/correction.rs
+++ b/src/correction.rs
@@ -45,9 +45,9 @@ pub(crate) fn correct_high_lux(lux: f32) -> f32 {
 }
 
 fn inverse_high_lux_correction(lux: f32) -> f32 {
-    // Inverse of the polinomial used to correct for lux > 1000.
+    // Inverse of the polynomial used to correct for lux > 1000.
     // `y = 6.0135e-13*(x^4) - 9.3924e-9*(x^3) + 8.1488e-5*(x^2) + 1.0023*x`.
-    // This runs into underflow/overlow issues if trying to solve it directly.
+    // This runs into underflow/overflow issues if trying to solve it directly.
     // However, it can be solved for unknown coefficients and then
     // we put in the values.
     -C2 / (4.0 * C3)

--- a/src/correction.rs
+++ b/src/correction.rs
@@ -1,5 +1,6 @@
 use crate::{Gain, IntegrationTime};
 
+#[cfg(feature = "lux_as_f32")]
 use micromath::F32Ext;
 
 /// Calculate raw value for threshold applying compensation if necessary.

--- a/src/correction.rs
+++ b/src/correction.rs
@@ -10,10 +10,10 @@ use micromath::F32Ext;
 pub fn calculate_raw_threshold_value(it: IntegrationTime, gain: Gain, lux: f32) -> u16 {
     let factor = get_lux_raw_conversion_factor(it, gain);
     if (gain == Gain::OneQuarter || gain == Gain::OneEighth) && lux > 1000.0 {
-        let lux = inverse_high_lux_correction(f32::from(lux));
-        (lux / f32::from(factor)) as u16
+        let lux = inverse_high_lux_correction(lux);
+        (lux / factor) as u16
     } else {
-        (f32::from(lux) / f32::from(factor)) as u16
+        (lux / factor) as u16
     }
 }
 

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -6,7 +6,7 @@ use crate::{
     Config, Error, FaultCount, Gain, IntegrationTime, InterruptStatus, PowerSavingMode, Veml7700,
     DEVICE_ADDRESS,
 };
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c::{ErrorType, I2c, SevenBitAddress};
 
 struct Register;
 impl Register {
@@ -41,9 +41,10 @@ impl Config {
     }
 }
 
-impl<I2C, E> Veml7700<I2C>
+impl<I2C> Veml7700<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: I2c<SevenBitAddress>,
+    I2C::Error: Into<Error<I2C::Error>>,
 {
     /// Create new instance of the VEML6040 device.
     pub fn new(i2c: I2C) -> Self {
@@ -63,28 +64,29 @@ where
     }
 }
 
-impl<I2C, E> Veml7700<I2C>
+impl<I2C> Veml7700<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: I2c<SevenBitAddress>,
+    I2C::Error: Into<Error<I2C::Error>>,
 {
     /// Enable the device.
     ///
     /// Note that when activating the sensor a wait time of 4 ms should be
     /// observed before the first measurement is picked up to allow for a
     /// correct start of the signal processor and oscillator.
-    pub fn enable(&mut self) -> Result<(), Error<E>> {
+    pub fn enable(&mut self) -> Result<(), Error<I2C::Error>> {
         let config = self.config.with_low(BitFlags::ALS_SD);
         self.set_config(config)
     }
 
     /// Disable the device (shutdown).
-    pub fn disable(&mut self) -> Result<(), Error<E>> {
+    pub fn disable(&mut self) -> Result<(), Error<I2C::Error>> {
         let config = self.config.with_high(BitFlags::ALS_SD);
         self.set_config(config)
     }
 
     /// Set the integration time.
-    pub fn set_integration_time(&mut self, it: IntegrationTime) -> Result<(), Error<E>> {
+    pub fn set_integration_time(&mut self, it: IntegrationTime) -> Result<(), Error<I2C::Error>> {
         let mask = match it {
             IntegrationTime::_25ms => 0b1100,
             IntegrationTime::_50ms => 0b1000,
@@ -100,7 +102,7 @@ where
     }
 
     /// Set the gain.
-    pub fn set_gain(&mut self, gain: Gain) -> Result<(), Error<E>> {
+    pub fn set_gain(&mut self, gain: Gain) -> Result<(), Error<I2C::Error>> {
         let mask = match gain {
             Gain::One => 0,
             Gain::Two => 1,
@@ -115,7 +117,7 @@ where
 
     /// Set the number of times a threshold crossing must happen consecutively
     /// to trigger an interrupt.
-    pub fn set_fault_count(&mut self, fc: FaultCount) -> Result<(), Error<E>> {
+    pub fn set_fault_count(&mut self, fc: FaultCount) -> Result<(), Error<I2C::Error>> {
         let mask = match fc {
             FaultCount::One => 0,
             FaultCount::Two => 1,
@@ -127,25 +129,25 @@ where
     }
 
     /// Enable interrupt generation.
-    pub fn enable_interrupts(&mut self) -> Result<(), Error<E>> {
+    pub fn enable_interrupts(&mut self) -> Result<(), Error<I2C::Error>> {
         let config = self.config.with_high(BitFlags::ALS_INT_EN);
         self.set_config(config)
     }
 
     /// Disable interrupt generation.
-    pub fn disable_interrupts(&mut self) -> Result<(), Error<E>> {
+    pub fn disable_interrupts(&mut self) -> Result<(), Error<I2C::Error>> {
         let config = self.config.with_low(BitFlags::ALS_INT_EN);
         self.set_config(config)
     }
 
     /// Set the ALS high threshold in raw format
-    pub fn set_high_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<E>> {
-        self.write_register(Register::ALS_WH, threshold)
+    pub fn set_high_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<I2C::Error>> {
+        Ok(self.write_register(Register::ALS_WH, threshold)?)
     }
 
     /// Set the ALS low threshold in raw format
-    pub fn set_low_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<E>> {
-        self.write_register(Register::ALS_WL, threshold)
+    pub fn set_low_threshold_raw(&mut self, threshold: u16) -> Result<(), Error<I2C::Error>> {
+        Ok(self.write_register(Register::ALS_WL, threshold)?)
     }
 
     /// Set the ALS high threshold in lux.
@@ -154,7 +156,7 @@ where
     /// the inverse of the compensation formula is applied (this involves
     /// quite some math).
     #[cfg(feature = "lux_as_f32")]
-    pub fn set_high_threshold_lux(&mut self, lux: f32) -> Result<(), Error<E>> {
+    pub fn set_high_threshold_lux(&mut self, lux: f32) -> Result<(), Error<I2C::Error>> {
         let raw = self.calculate_raw_threshold_value(lux);
         self.set_high_threshold_raw(raw)
     }
@@ -166,7 +168,7 @@ where
     /// the inverse of the compensation formula is applied (this involves
     /// quite some math).
     #[cfg(feature = "lux_as_f32")]
-    pub fn set_low_threshold_lux(&mut self, lux: f32) -> Result<(), Error<E>> {
+    pub fn set_low_threshold_lux(&mut self, lux: f32) -> Result<(), Error<I2C::Error>> {
         let raw = self.calculate_raw_threshold_value(lux);
         self.set_low_threshold_raw(raw)
     }
@@ -185,7 +187,7 @@ where
     }
 
     /// Enable the power-saving mode
-    pub fn enable_power_saving(&mut self, psm: PowerSavingMode) -> Result<(), Error<E>> {
+    pub fn enable_power_saving(&mut self, psm: PowerSavingMode) -> Result<(), Error<I2C::Error>> {
         let mask = match psm {
             PowerSavingMode::One => 0,
             PowerSavingMode::Two => 1,
@@ -193,37 +195,41 @@ where
             PowerSavingMode::Four => 3,
         };
         let value = BitFlags::PSM_EN | mask << 1;
-        self.write_register(Register::PSM, value)
+        Ok(self.write_register(Register::PSM, value)?)
     }
 
     /// Disable the power-saving mode
-    pub fn disable_power_saving(&mut self) -> Result<(), Error<E>> {
-        self.write_register(Register::PSM, 0)
+    pub fn disable_power_saving(&mut self) -> Result<(), Error<I2C::Error>> {
+        Ok(self.write_register(Register::PSM, 0)?)
     }
 
-    fn set_config(&mut self, config: Config) -> Result<(), Error<E>> {
+    fn set_config(&mut self, config: Config) -> Result<(), Error<I2C::Error>> {
         self.write_register(Register::ALS_CONF, config.bits)?;
         self.config = config;
         Ok(())
     }
 
-    fn write_register(&mut self, register: u8, value: u16) -> Result<(), Error<E>> {
+    fn write_register(
+        &mut self,
+        register: u8,
+        value: u16,
+    ) -> Result<(), <I2C as ErrorType>::Error> {
         self.i2c
             .write(DEVICE_ADDRESS, &[register, value as u8, (value >> 8) as u8])
-            .map_err(Error::I2C)
     }
 }
 
-impl<I2C, E> Veml7700<I2C>
+impl<I2C> Veml7700<I2C>
 where
-    I2C: i2c::WriteRead<Error = E>,
+    I2C: I2c<SevenBitAddress>,
+    I2C::Error: Into<Error<I2C::Error>>,
 {
     /// Read whether an interrupt has occurred.
     ///
     /// Note that the interrupt status is updated at the same rate as the
     /// measurements. Once triggered, flags will stay true until a measurement
     /// is taken which does not exceed the threshold.
-    pub fn read_interrupt_status(&mut self) -> Result<InterruptStatus, Error<E>> {
+    pub fn read_interrupt_status(&mut self) -> Result<InterruptStatus, Error<I2C::Error>> {
         let data = self.read_register(Register::ALS_INT)?;
         Ok(InterruptStatus {
             was_too_low: (data & BitFlags::INT_TH_LOW) != 0,
@@ -232,7 +238,7 @@ where
     }
 
     /// Read ALS high resolution output data in raw format
-    pub fn read_raw(&mut self) -> Result<u16, Error<E>> {
+    pub fn read_raw(&mut self) -> Result<u16, Error<I2C::Error>> {
         self.read_register(Register::ALS)
     }
 
@@ -242,7 +248,7 @@ where
     /// the following compensation formula is applied:
     /// `lux = 6.0135e-13*(lux^4) - 9.3924e-9*(lux^3) + 8.1488e-5*(lux^2) + 1.0023*lux`
     #[cfg(feature = "lux_as_f32")]
-    pub fn read_lux(&mut self) -> Result<f32, Error<E>> {
+    pub fn read_lux(&mut self) -> Result<f32, Error<I2C::Error>> {
         let raw = self.read_register(Register::ALS)?;
         Ok(self.convert_raw_als_to_lux(raw))
     }
@@ -261,11 +267,11 @@ where
     }
 
     /// Read white channel measurement
-    pub fn read_white(&mut self) -> Result<u16, Error<E>> {
+    pub fn read_white(&mut self) -> Result<u16, Error<I2C::Error>> {
         self.read_register(Register::WHITE)
     }
 
-    fn read_register(&mut self, register: u8) -> Result<u16, Error<E>> {
+    fn read_register(&mut self, register: u8) -> Result<u16, Error<I2C::Error>> {
         let mut data = [0; 2];
         self.i2c
             .write_read(DEVICE_ADDRESS, &[register], &mut data)
@@ -282,10 +288,10 @@ where
 #[cfg(feature = "lux_as_f32")]
 pub fn convert_raw_als_to_lux(it: IntegrationTime, gain: Gain, raw_als: u16) -> f32 {
     let factor = get_lux_raw_conversion_factor(it, gain);
-    let lux = f32::from(raw_als) * f32::from(factor);
+    let lux = f32::from(raw_als) * factor;
     if (gain == Gain::OneQuarter || gain == Gain::OneEighth) && lux > 1000.0 {
-        correct_high_lux(lux) as f32
+        correct_high_lux(lux)
     } else {
-        lux as f32
+        lux
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,15 @@
 #![deny(unsafe_code, missing_docs)]
 #![no_std]
 
+#[cfg(feature = "lux_as_f32")]
 mod correction;
+
 mod device_impl;
 mod types;
 
+#[cfg(feature = "lux_as_f32")]
 pub use crate::correction::calculate_raw_threshold_value;
+#[cfg(feature = "lux_as_f32")]
 pub use crate::device_impl::convert_raw_als_to_lux;
 
 pub use crate::types::{FaultCount, Gain, IntegrationTime, InterruptStatus, PowerSavingMode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,11 @@ pub enum Error<E> {
     /// I²C bus error
     I2C(E),
 }
+impl<E> From<E> for Error<E> {
+    fn from(other: E) -> Self {
+        Error::I2C(other)
+    }
+}
 
 const DEVICE_ADDRESS: u8 = 0x10;
 


### PR DESCRIPTION
We needed to operates on non-floating-point processors. We've used conditional compilation to preserve the floating-point behaviors when desired (and kept them as the default behavior.)
In doing so, we needed compatibility with changes to the embedded-hal as it progressed to version 1.0.0.