### PR TITLE
Revert "support async via maybe-async"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,12 @@ repository = "https://github.com/no111u3/veml7700"
 exclude = ["memory.x", ".cargo", "Embed.toml"]
 
 [features]
-default = ["is_sync", "lux_as_f32"]
+default = ["lux_as_f32"]
 lux_as_f32 = ["micromath"]
 lux_as_u32 = []
-is_sync = ["maybe-async/is_sync"]
 
 [dependencies]
-async-generic = "1.1.0"
 embedded-hal = "1.0.0"
-embedded-hal-async = "1.0.0"
-maybe-async = { version = "0.2.10" }
 micromath = { version = "2.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Reverts no111u3/veml7700#4 Because it can't be compiled without asynchronous mode.